### PR TITLE
Update GeolocationService.cs

### DIFF
--- a/Darnton.Blazor.DeviceInterop/Geolocation/GeolocationService.cs
+++ b/Darnton.Blazor.DeviceInterop/Geolocation/GeolocationService.cs
@@ -21,7 +21,7 @@ namespace Darnton.Blazor.DeviceInterop.Geolocation
         /// <param name="JSRuntime"></param>
         public GeolocationService(IJSRuntime JSRuntime)
         {
-            _jsBinder = new JSBinder(JSRuntime, "./_content/Darnton.Blazor.DeviceInterop/js/geolocation.js");
+            _jsBinder = new JSBinder(JSRuntime, "./_content/Darnton.Blazor.DeviceInterop/js/Geolocation.js");
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Case sensitivity is an issue if hosting a blazor app in AWS S3.  
It won't find the geolocation.js file because it has an uppercase "G" in the filename in the js folder.